### PR TITLE
Construct GTFS ID from the location name (column 0) and direction (column 3)

### DIFF
--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/MergeStopIdsFromControlStrategy.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/MergeStopIdsFromControlStrategy.java
@@ -27,13 +27,14 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 
 /**
- * using crontrol file re-map GTFS stop ids and other stop properties
+ * using control file re-map GTFS stop ids and other stop properties
  */
 public class MergeStopIdsFromControlStrategy implements GtfsTransformStrategy {
 
     private final Logger _log = LoggerFactory.getLogger(MergeStopIdsFromControlStrategy.class);
 
     private static final int LOCATION_NAME_INDEX = 0;
+    private static final int DIRECTION_INDEX = 3;
     private static final int ATIS_ID_INDEX = 6;
 
     @Override
@@ -54,12 +55,19 @@ public class MergeStopIdsFromControlStrategy implements GtfsTransformStrategy {
                 _log.info("bad control line {}", controlLine);
                 continue;
             }
+
             String gtfsId = controlArray[LOCATION_NAME_INDEX];
+            String gtfsDirection = controlArray[DIRECTION_INDEX];
+
             String atisId = controlArray[ATIS_ID_INDEX];
 
-            Stop gtfsStop = reference.getStopForId(new AgencyAndId(getReferenceAgencyId(reference), gtfsId));
+            String constructedGtfsId = gtfsId + gtfsDirection;
+
+            Stop gtfsStop = reference.getStopForId(new AgencyAndId(getReferenceAgencyId(reference), constructedGtfsId));
+
             if (gtfsStop == null) {
-                _log.info("missing reference stop {} for agency {}", gtfsId, getReferenceAgencyId(reference));
+                _log.info("missing reference stop {} for agency {}", constructedGtfsId,
+                        getReferenceAgencyId(reference));
                 unmatched++;
                 continue;
             }


### PR DESCRIPTION
For consistency with the existing GTFS feed, the mapped GTFS ID should be constructed from the RTIF location ID (column 0) and the direction (column 3).  In other words, ATIS stop `1` becomes GTFS stop `101N`, and ATIS stop `31803` becomes GTFS stop `101S`.


#location_name | Track | Line | Direction | DOW | board/alight flag | Atis Stopid | RTIF Description | ATIS Stop Description
-- | -- | -- | -- | -- | -- | -- | -- | --
101 |   |   | N |   |   | 1 | 242ND ST-VAN CORTLANDT PK | 242ND ST-VAN CORTLANDT PK 1 [NORTHBOUND]
101 |   |   | S |   |   | 31803 | 242ND ST-VAN CORTLANDT PK | 242ND ST-VAN CORTLANDT PK 1[SOUTHBOUND]

(Note that this code compiles but I have not tested it with live data.)
